### PR TITLE
feature(extension.webpack-babel): add options presets and remove react support

### DIFF
--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -14,11 +14,14 @@
     "@zero-scripts/extension.webpack-babel": "^0.1.0-alpha.2",
     "@zero-scripts/extension.webpack-css": "^0.1.0-alpha.2",
     "@zero-scripts/extension.webpack-eslint": "^0.1.0-alpha.2",
-    "@zero-scripts/preset.webpack-spa": "^0.1.0-alpha.2"
+    "@zero-scripts/preset.webpack-spa": "^0.1.0-alpha.2",
+    "@babel/preset-react": "^7.0.0"
   },
   "zero-scripts": {
     "@zero-scripts/extension.webpack-babel": {
-      "react": true
+      "presets": [
+        "@babel/preset-react"
+      ]
     }
   }
 }

--- a/packages/extension.webpack-babel/README.md
+++ b/packages/extension.webpack-babel/README.md
@@ -4,9 +4,9 @@ Adds Babel to `@zero-scripts/config.webpack`
 
 ## Options
 
-| Option | Type      | Default |
-| ------ | --------- | ------- |
-| react  | _Boolean_ | `false` |
+| Option  | Type       | Default |
+| ------- | ---------- | ------- |
+| presets | _string[]_ | `[]`    |
 
 ## Example
 
@@ -20,7 +20,7 @@ Adds Babel to `@zero-scripts/config.webpack`
   },
   "zero-scripts": {
     "@zero-scripts/extension.webpack-babel": {
-      "react": true
+      "presets": ["@babel/preset-react"]
     }
   }
 }

--- a/packages/extension.webpack-babel/package.json
+++ b/packages/extension.webpack-babel/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
-    "@babel/preset-react": "^7.0.0",
     "@zero-scripts/config.webpack": "^0.1.0-alpha.2",
     "@zero-scripts/core": "^0.1.0-alpha.2",
     "babel-loader": "^8.0.4"

--- a/packages/extension.webpack-babel/src/index.ts
+++ b/packages/extension.webpack-babel/src/index.ts
@@ -1,9 +1,13 @@
 import { AbstractExtension } from '@zero-scripts/core';
 import { WebpackConfig } from '@zero-scripts/config.webpack';
 
-export class WebpackBabelExtension extends AbstractExtension<{
-  react: boolean;
-}> {
+export type WebpackBabelExtensionOptions = {
+  presets: string[];
+};
+
+export class WebpackBabelExtension extends AbstractExtension<
+  WebpackBabelExtensionOptions
+> {
   public activate(): void {
     this.preset
       .getInstance(WebpackConfig)
@@ -20,11 +24,10 @@ export class WebpackBabelExtension extends AbstractExtension<{
                 options: {
                   babelrc: false,
                   configFile: false,
-                  presets: [require.resolve('@babel/preset-env')].concat(
-                    this.options.react
-                      ? require.resolve('@babel/preset-react')
-                      : []
-                  )
+                  presets: [
+                    require.resolve('@babel/preset-env'),
+                    ...(this.options.presets ? this.options.presets : [])
+                  ]
                 }
               }
             },


### PR DESCRIPTION
BREAKING CHANGE: `extension.webpack-babel` cannot contain support for react more
NEW FEATURE: you can pass presets to `extension.webpack-babel` and `extension.webpack-babel.react`

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Minor: New Feature?      | +
| Major: Breaking Change?  | +
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
