### PR TITLE
improvement(core): move options reading logic to read-options decorator

### DIFF
--- a/packages/config.webpack/src/WebpackConfig.ts
+++ b/packages/config.webpack/src/WebpackConfig.ts
@@ -4,7 +4,9 @@ import { validateWebpackConfig } from './validateWebpackConfig';
 import { createWebpackConfig } from './createWebpackConfig';
 import { WebpackConfigOptions } from './WebpackConfigOptions';
 import { resolvePath } from './utils/resolvePath';
+import { ReadOptions } from '@zero-scripts/core';
 
+@ReadOptions()
 export class WebpackConfig extends AbstractConfigBuilder<
   Configuration,
   WebpackConfigOptions

--- a/packages/core/src/decorators/ReadOptions.ts
+++ b/packages/core/src/decorators/ReadOptions.ts
@@ -1,0 +1,45 @@
+import { readZeroScriptsOptions } from '../utils/readZeroScriptsOptions';
+import { splitByUpperCase } from '../utils/splitByUpperCase';
+
+export const ReadOptions = (optionsKey?: string) => <
+  T extends { new (...args: any[]): any }
+>(
+  DecoratedClass: T
+) =>
+  class extends DecoratedClass {
+    constructor(...args: any[]) {
+      // checking if options are derived from inherit classes
+      // used on subsequent decorator override
+      if (args[0]) {
+        super(args[0]);
+      } else {
+        const zeroScriptsOptions = readZeroScriptsOptions();
+
+        // if optionsKey not defined
+        // find suitable key by
+        // split class name
+        const key = !optionsKey
+          ? zeroScriptsOptions &&
+            Object.keys(zeroScriptsOptions).find(packageName => {
+              let isSuitable = false;
+              splitByUpperCase(DecoratedClass.name).forEach(word => {
+                const currentIndexOf = packageName.indexOf(word);
+                isSuitable = currentIndexOf !== -1;
+              });
+              return isSuitable;
+            })
+          : optionsKey;
+
+        const needOptions =
+          key && typeof zeroScriptsOptions[key] === 'object'
+            ? zeroScriptsOptions[key]
+            : {};
+
+        console.log(
+          `${key || DecoratedClass.name}: ${JSON.stringify(needOptions)}`
+        );
+
+        super(needOptions);
+      }
+    }
+  };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,3 +3,4 @@ export * from './AbstractPreset';
 export * from './AbstractExtension';
 export * from './runCLI';
 export * from './InsertPos';
+export * from './decorators/ReadOptions';

--- a/packages/core/src/utils/readZeroScriptsOptions.ts
+++ b/packages/core/src/utils/readZeroScriptsOptions.ts
@@ -1,0 +1,10 @@
+import { readPackageJson } from './readPackageJson';
+
+const packageJsonOptionsKey = 'zero-scripts';
+
+export const readZeroScriptsOptions = (key?: string) =>
+  readPackageJson(data =>
+    key
+      ? data[packageJsonOptionsKey] && data[packageJsonOptionsKey][key]
+      : data[packageJsonOptionsKey]
+  );

--- a/packages/ts-config/tsconfig.json
+++ b/packages/ts-config/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "composite": true
+    "composite": true,
+    "experimentalDecorators": true
   }
 }


### PR DESCRIPTION
It's a fix too, because get-instance should not contains this logic

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| License                  | MIT
